### PR TITLE
Add DLQ Redrive Lambda to Reprocess Failed Messages with Delay

### DIFF
--- a/processing-service/src/main/java/com/process/handler/DLQRedriveHandler.java
+++ b/processing-service/src/main/java/com/process/handler/DLQRedriveHandler.java
@@ -1,0 +1,137 @@
+package com.process.handler;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.RequestHandler;
+import com.amazonaws.services.lambda.runtime.events.ScheduledEvent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.services.sqs.SqsClient;
+import software.amazon.awssdk.services.sqs.model.*;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Lambda function that moves messages from Dead Letter Queue back to the main retry queue
+ * with a configured delay to allow for retry processing of failed image processing requests.
+ */
+public class DLQRedriveHandler implements RequestHandler<ScheduledEvent, Map<String, Object>> {
+
+    private static final Logger logger = LoggerFactory.getLogger(DLQRedriveHandler.class);
+    private static final int DELAY_SECONDS = 300;
+    private static final int MAX_MESSAGES_PER_BATCH = 10;
+
+    private final SqsClient sqsClient;
+    private final String dlqUrl;
+    private final String retryQueueUrl;
+    private final int maxMessagesToRedrive;
+
+    public DLQRedriveHandler() {
+        this.sqsClient = SqsClient.create();
+        this.dlqUrl = System.getenv("DLQ_URL");
+        this.retryQueueUrl = System.getenv("RETRY_QUEUE_URL");
+
+        String maxMessagesEnv = System.getenv("MAX_MESSAGES_TO_REDRIVE");
+        this.maxMessagesToRedrive = (maxMessagesEnv != null) ?
+                Integer.parseInt(maxMessagesEnv) : 100;
+
+        logger.info("Initialized DLQ Redrive Handler with DLQ: {}, Retry Queue: {}, Max Messages: {}",
+                dlqUrl, retryQueueUrl, maxMessagesToRedrive);
+    }
+
+    @Override
+    public Map<String, Object> handleRequest(ScheduledEvent scheduledEvent, Context context) {
+        logger.info("Starting DLQ redrive process");
+        Map<String, Object> result = new HashMap<>();
+
+        int totalMessagesRedriven = 0;
+        int successCount = 0;
+        int failureCount = 0;
+
+        try {
+            GetQueueAttributesResponse queueAttributes = sqsClient.getQueueAttributes(
+                    GetQueueAttributesRequest.builder()
+                            .queueUrl(dlqUrl)
+                            .attributeNames(QueueAttributeName.APPROXIMATE_NUMBER_OF_MESSAGES)
+                            .build());
+
+            String approximateNumberOfMessagesStr = queueAttributes.attributes()
+                    .get(QueueAttributeName.APPROXIMATE_NUMBER_OF_MESSAGES.toString());
+            int approximateNumberOfMessages = Integer.parseInt(approximateNumberOfMessagesStr);
+
+            logger.info("Found approximately {} messages in DLQ", approximateNumberOfMessages);
+
+            // Determine how many messages to process
+            int messagesToProcess = Math.min(approximateNumberOfMessages, maxMessagesToRedrive);
+            int batchesNeeded = (int) Math.ceil((double) messagesToProcess / MAX_MESSAGES_PER_BATCH);
+
+            for (int batch = 0; batch < batchesNeeded && totalMessagesRedriven < maxMessagesToRedrive; batch++) {
+                // Receive messages from DLQ
+                ReceiveMessageResponse receiveResponse = sqsClient.receiveMessage(
+                        ReceiveMessageRequest.builder()
+                                .queueUrl(dlqUrl)
+                                .maxNumberOfMessages(MAX_MESSAGES_PER_BATCH)
+                                .visibilityTimeout(30)
+                                .waitTimeSeconds(1)
+                                .build());
+
+                List<Message> messages = receiveResponse.messages();
+
+                if (messages.isEmpty()) {
+                    logger.info("No more messages in DLQ to process");
+                    break;
+                }
+
+                logger.info("Processing batch {} with {} messages", batch + 1, messages.size());
+
+                // Process messages - send to retry queue and delete from DLQ
+                for (Message message : messages) {
+                    try {
+                        sqsClient.sendMessage(
+                                SendMessageRequest.builder()
+                                        .queueUrl(retryQueueUrl)
+                                        .messageBody(message.body())
+                                        .delaySeconds(DELAY_SECONDS)
+                                        .build());
+
+                        sqsClient.deleteMessage(
+                                DeleteMessageRequest.builder()
+                                        .queueUrl(dlqUrl)
+                                        .receiptHandle(message.receiptHandle())
+                                        .build());
+
+                        successCount++;
+                        logger.debug("Successfully redrove message {}", message.messageId());
+                    } catch (Exception e) {
+                        failureCount++;
+                        logger.error("Failed to redrive message {}: {}",
+                                message.messageId(), e.getMessage(), e);
+                    }
+
+                    totalMessagesRedriven++;
+
+                    if (totalMessagesRedriven >= maxMessagesToRedrive) {
+                        logger.info("Reached maximum number of messages to redrive: {}", maxMessagesToRedrive);
+                        break;
+                    }
+                }
+            }
+
+            logger.info("DLQ redrive completed. Total: {}, Success: {}, Failure: {}",
+                    totalMessagesRedriven, successCount, failureCount);
+
+            result.put("status", "success");
+            result.put("messagesProcessed", totalMessagesRedriven);
+            result.put("successCount", successCount);
+            result.put("failureCount", failureCount);
+
+        } catch (Exception e) {
+            logger.error("Error in DLQ redrive process: {}", e.getMessage(), e);
+            result.put("status", "error");
+            result.put("error", e.getMessage());
+        }
+
+        return result;
+    }
+}

--- a/processing-service/src/main/java/com/process/util/DynamoDbService.java
+++ b/processing-service/src/main/java/com/process/util/DynamoDbService.java
@@ -32,7 +32,7 @@ public class DynamoDbService {
      * @param firstName The user's first name
      * @param lastName  The user's last name
      */
-    public void storeImageMetadata(String userId, String imageKey, String firstName, String lastName) {
+    public void storeImageMetadata(String userId, String imageKey, String firstName, String lastName, String imageUrl) {
         try {
             // Create item attributes
             Map<String, AttributeValue> item = new HashMap<>();
@@ -45,6 +45,8 @@ public class DynamoDbService {
             item.put("firstName", AttributeValue.builder().s(firstName).build());
             item.put("lastName", AttributeValue.builder().s(lastName).build());
             item.put("processedDate", AttributeValue.builder().s(Instant.now().toString()).build());
+            item.put("imageUrl", AttributeValue.builder().s(imageUrl).build());
+
 
             // Set TTL for 30 days (if used)
             long ttl = Instant.now().plus(30, ChronoUnit.DAYS).getEpochSecond();

--- a/processing-service/src/main/java/com/process/util/DynamoDbService.java
+++ b/processing-service/src/main/java/com/process/util/DynamoDbService.java
@@ -24,41 +24,28 @@ public class DynamoDbService {
         System.out.println("DynamoDbService initialized with tableName: " + tableName + " in region: " + region);
     }
 
-    /**
-     * Stores image metadata in DynamoDB
-     *
-     * @param userId    The user ID
-     * @param imageKey  The image key in the processed bucket
-     * @param firstName The user's first name
-     * @param lastName  The user's last name
-     */
+
     public void storeImageMetadata(String userId, String imageKey, String firstName, String lastName, String imageUrl) {
         try {
-            // Create item attributes
             Map<String, AttributeValue> item = new HashMap<>();
 
-            // Primary key attributes
             item.put("userId", AttributeValue.builder().s(userId).build());
             item.put("imageKey", AttributeValue.builder().s(imageKey).build());
 
-            // Other attributes
             item.put("firstName", AttributeValue.builder().s(firstName).build());
             item.put("lastName", AttributeValue.builder().s(lastName).build());
             item.put("processedDate", AttributeValue.builder().s(Instant.now().toString()).build());
             item.put("imageUrl", AttributeValue.builder().s(imageUrl).build());
 
 
-            // Set TTL for 30 days (if used)
             long ttl = Instant.now().plus(30, ChronoUnit.DAYS).getEpochSecond();
             item.put("ttl", AttributeValue.builder().n(String.valueOf(ttl)).build());
 
-            // Create request
             PutItemRequest request = PutItemRequest.builder()
                     .tableName(tableName)
                     .item(item)
                     .build();
 
-            // Put item in the table
             dynamoDbClient.putItem(request);
             System.out.println("Successfully stored metadata for image: " + imageKey);
 

--- a/processing-service/src/main/java/com/process/util/EmailService.java
+++ b/processing-service/src/main/java/com/process/util/EmailService.java
@@ -9,19 +9,14 @@ import java.util.logging.Logger;
 public class EmailService {
 
     private final SesClient sesClient;
-    private final String sourceEmail = "samuel.asante@amalitech.com";
+    private final String sourceEmail = "no-reply@mscv2group1.link";
 
     public EmailService(String regionName) {
         Region region = Region.of(regionName);
         this.sesClient = SesClient.builder().region(region).build();
     }
 
-    /**
-     * Sends an email notification when processing starts
-     *
-     * @param email Recipient email address
-     * @param firstName User's first name
-     */
+
     public void sendProcessingStartEmail(String email, String firstName) {
         String subject = "Your Image is Processing";
         String htmlBody = "<html><body>" +
@@ -34,13 +29,6 @@ public class EmailService {
         sendEmail(email, subject, htmlBody);
     }
 
-    /**
-     * Sends an email notification when processing completes successfully
-     *
-     * @param email Recipient email address
-     * @param firstName User's first name
-     * @param imageKey S3 key of the processed image
-     */
     public void sendProcessingCompleteEmail(String email, String firstName, String imageKey) {
         String subject = "Your Image Processing is Complete";
         String htmlBody = "<html><body>" +
@@ -52,12 +40,6 @@ public class EmailService {
         sendEmail(email, subject, htmlBody);
     }
 
-    /**
-     * Sends an email notification when processing fails
-     *
-     * @param email Recipient email address
-     * @param firstName User's first name
-     */
     public void sendProcessingFailureEmail(String email, String firstName) {
         String subject = "Image Processing Failed";
         String htmlBody = "<html><body>" +
@@ -71,13 +53,7 @@ public class EmailService {
         sendEmail(email, subject, htmlBody);
     }
 
-    /**
-     * Sends an email using Amazon SES
-     *
-     * @param recipient Recipient email address
-     * @param subject Email subject
-     * @param htmlBody Email body in HTML format
-     */
+
     private void sendEmail(String recipient, String subject, String htmlBody) {
         Destination destination = Destination.builder()
                 .toAddresses(recipient)

--- a/processing-service/src/main/java/com/process/util/EmailService.java
+++ b/processing-service/src/main/java/com/process/util/EmailService.java
@@ -4,10 +4,12 @@ import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.ses.SesClient;
 import software.amazon.awssdk.services.ses.model.*;
 
+import java.util.logging.Logger;
+
 public class EmailService {
 
     private final SesClient sesClient;
-    private final String sourceEmail = "noreply@mscv2group1.link";
+    private final String sourceEmail = "samuel.asante@amalitech.com";
 
     public EmailService(String regionName) {
         Region region = Region.of(regionName);
@@ -103,6 +105,10 @@ public class EmailService {
                 .destination(destination)
                 .message(message)
                 .build();
+
+        Logger.getAnonymousLogger().info(sendEmailRequest.destination().toString());
+        Logger.getAnonymousLogger().info(sourceEmail.toString());
+        Logger.getAnonymousLogger().info(message.toString());
 
         sesClient.sendEmail(sendEmailRequest);
     }

--- a/processing-service/src/main/java/com/process/util/EmailService.java
+++ b/processing-service/src/main/java/com/process/util/EmailService.java
@@ -9,7 +9,7 @@ import java.util.logging.Logger;
 public class EmailService {
 
     private final SesClient sesClient;
-    private final String sourceEmail = "no-reply@mscv2group1.link";
+    private final String sourceEmail = "no-reply@mscv2group2.link";
 
     public EmailService(String regionName) {
         Region region = Region.of(regionName);

--- a/processing-service/src/main/java/com/process/util/ImageProcessor.java
+++ b/processing-service/src/main/java/com/process/util/ImageProcessor.java
@@ -14,27 +14,16 @@ import java.util.logging.Logger;
 public class ImageProcessor {
     private static final Logger logger = Logger.getLogger(ImageProcessor.class.getName());
 
-    /**
-     * Adds a watermark to an image
-     *
-     * @param imageBytes The original image as byte array
-     * @param firstName User's first name for the watermark
-     * @param lastName User's last name for the watermark
-     * @return The watermarked image as byte array
-     * @throws IOException If image processing fails
-     */
+
     public byte[] addWatermark(byte[] imageBytes, String firstName, String lastName) throws IOException {
         if (imageBytes == null || imageBytes.length == 0) {
             throw new IOException("Image byte array is null or empty");
         }
 
-        // Log image byte array size for debugging
         logger.info("Image byte array size: " + imageBytes.length + " bytes");
 
-        // Try to detect image format before processing
         ByteArrayInputStream inputStream = new ByteArrayInputStream(imageBytes);
 
-        // Check if this is a valid image by attempting to determine its format
         try {
             if (ImageIO.read(new ByteArrayInputStream(imageBytes.clone())) == null) {
                 throw new IOException("Invalid image format or corrupted image data");
@@ -43,10 +32,8 @@ public class ImageProcessor {
             throw new IOException("Error validating image format: " + e.getMessage(), e);
         }
 
-        // Reset the input stream
         inputStream.reset();
 
-        // Read the image with explicit error checking
         BufferedImage sourceImage;
         try {
             sourceImage = ImageIO.read(inputStream);
@@ -57,39 +44,31 @@ public class ImageProcessor {
             throw new IOException("Error reading image data: " + e.getMessage(), e);
         }
 
-        // Log image dimensions for debugging
         logger.info("Read image successfully. Dimensions: " + sourceImage.getWidth() + "x" + sourceImage.getHeight());
 
-        // Create a new image with watermark
         BufferedImage watermarkedImage = new BufferedImage(
                 sourceImage.getWidth(),
                 sourceImage.getHeight(),
                 BufferedImage.TYPE_INT_RGB);
 
-        // Draw the original image
         Graphics2D g2d = watermarkedImage.createGraphics();
         g2d.drawImage(sourceImage, 0, 0, null);
 
-        // Set watermark properties
         g2d.setFont(new Font("Arial", Font.BOLD, 50));
         g2d.setColor(new Color(255, 255, 255, 128));
 
-        // Create watermark text
         String date = LocalDate.now().format(DateTimeFormatter.ISO_LOCAL_DATE);
         String watermarkText = firstName + " " + lastName + " - " + date;
 
         FontMetrics fontMetrics = g2d.getFontMetrics();
         int textWidth = fontMetrics.stringWidth(watermarkText);
 
-        // Position watermark at bottom right
         int x = sourceImage.getWidth() - textWidth - 10;
         int y = sourceImage.getHeight() - 10;
 
-        // Add watermark
         g2d.drawString(watermarkText, x, y);
         g2d.dispose();
 
-        // Convert the watermarked image back to bytes
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
         ImageIO.write(watermarkedImage, "jpg", outputStream);
 

--- a/processing-service/src/main/java/com/process/util/ProcessImage.java
+++ b/processing-service/src/main/java/com/process/util/ProcessImage.java
@@ -13,11 +13,9 @@ public class ProcessImage {
         this.imageProcessor = imageProcessor;
     }
 
-    //    private final String stagingBucket;
     public void processImage(Context context, String bucket, String key, String userId,
                              String email, String firstName, String lastName, S3Service s3Service) {
         try {
-            // Get image data with better error reporting
             context.getLogger().log("Retrieving image from S3: " + bucket + "/" + key);
             byte[] imageData = s3Service.getImageFromS3(bucket, key);
 
@@ -28,7 +26,6 @@ public class ProcessImage {
 
             context.getLogger().log("Retrieved image data size: " + imageData.length + " bytes");
 
-            // Add watermark to the image
             context.getLogger().log("Adding watermark to image");
             emailService.sendProcessingStartEmail(email, firstName);
             byte[] watermarkedImage = imageProcessor.addWatermark(imageData, firstName, lastName);
@@ -40,25 +37,20 @@ public class ProcessImage {
 
             context.getLogger().log("Watermarked image size: " + watermarkedImage.length + " bytes");
 
-            // Generate a unique ID for the processed image
             String processedKey = "processed/" + java.util.UUID.randomUUID() + "-" +
                     key.substring(key.lastIndexOf("/") + 1);
 
-            // Upload the processed image to the processed bucket
             context.getLogger().log("Uploading processed image to S3");
             s3Service.uploadToProcessedBucket(watermarkedImage, processedKey);
 
-            // Store image metadata in DynamoDB
             context.getLogger().log("Storing image metadata in DynamoDB");
             String imageUrl = "https://" + System.getenv("PROCESSED_BUCKET")+ ".s3." + System.getenv("AWS_REGION") + ".amazonaws.com/" + processedKey;
 
             dynamoDbService.storeImageMetadata(userId, processedKey, firstName, lastName, imageUrl);
 
-            // Delete the original image from the staging bucket
             context.getLogger().log("Deleting original image from staging bucket");
             s3Service.deleteFromStagingBucket(bucket, key);
 
-            // Send completion email
             context.getLogger().log("Sending completion email to: " + email);
             if (email != null && !email.trim().isEmpty()) {
                 try {
@@ -66,7 +58,6 @@ public class ProcessImage {
                     context.getLogger().log("Email sent to the receiver");
                 } catch (Exception e) {
                     context.getLogger().log("Failed to send email: " + e.getMessage());
-                    // Continue processing even if email fails
                 }
 
             }
@@ -78,12 +69,11 @@ public class ProcessImage {
                 context.getLogger().log("Caused by: " + e.getCause().getMessage());
             }
 
-            // For debugging only - in production, don't print full stack traces to logs
             for (StackTraceElement element : e.getStackTrace()) {
                 context.getLogger().log("  at " + element.toString());
             }
             emailService.sendProcessingFailureEmail(email, firstName );
-            throw new RuntimeException("Failed to process image", e); // Re-throw to trigger retry or DLQ handling
+            throw new RuntimeException("Failed to process image", e);
         }
     }
 }

--- a/processing-service/src/main/java/com/process/util/ProcessImage.java
+++ b/processing-service/src/main/java/com/process/util/ProcessImage.java
@@ -50,7 +50,9 @@ public class ProcessImage {
 
             // Store image metadata in DynamoDB
             context.getLogger().log("Storing image metadata in DynamoDB");
-            dynamoDbService.storeImageMetadata(userId, processedKey, firstName, lastName);
+            String imageUrl = "https://" + System.getenv("PROCESSED_BUCKET")+ ".s3." + System.getenv("AWS_REGION") + ".amazonaws.com/" + processedKey;
+
+            dynamoDbService.storeImageMetadata(userId, processedKey, firstName, lastName, imageUrl);
 
             // Delete the original image from the staging bucket
             context.getLogger().log("Deleting original image from staging bucket");
@@ -61,10 +63,12 @@ public class ProcessImage {
             if (email != null && !email.trim().isEmpty()) {
                 try {
                     emailService.sendProcessingCompleteEmail(email, firstName, processedKey);
+                    context.getLogger().log("Email sent to the receiver");
                 } catch (Exception e) {
                     context.getLogger().log("Failed to send email: " + e.getMessage());
                     // Continue processing even if email fails
                 }
+
             }
 
             context.getLogger().log("Successfully processed image: " + key);

--- a/processing-service/src/main/java/com/process/util/S3Service.java
+++ b/processing-service/src/main/java/com/process/util/S3Service.java
@@ -23,13 +23,6 @@ public class S3Service {
                 " in region: " + region);
     }
 
-    /**
-     * Checks if an object exists in S3
-     *
-     * @param bucket The bucket name
-     * @param key    The object key
-     * @return True if the object exists, false otherwise
-     */
     public boolean objectExists(String bucket, String key) {
         try {
             HeadObjectRequest headObjectRequest = HeadObjectRequest.builder()
@@ -45,14 +38,7 @@ public class S3Service {
         }
     }
 
-    /**
-     * Retrieves an image from S3
-     *
-     * @param bucket The bucket name
-     * @param key    The object key
-     * @return The image as byte array
-     * @throws IOException If the image cannot be retrieved
-     */
+
     public byte[] getImageFromS3(String bucket, String key) throws IOException {
         try {
             GetObjectRequest getObjectRequest = GetObjectRequest.builder()
@@ -66,13 +52,6 @@ public class S3Service {
         }
     }
 
-    /**
-     * Uploads a processed image to the processed bucket
-     *
-     * @param imageData The image data as byte array
-     * @param key       The object key
-     * @throws IOException If the upload fails
-     */
     public void uploadToProcessedBucket(byte[] imageData, String key) throws IOException {
         try {
             PutObjectRequest putObjectRequest = PutObjectRequest.builder()
@@ -87,13 +66,7 @@ public class S3Service {
         }
     }
 
-    /**
-     * Deletes an image from the staging bucket
-     *
-     * @param bucket The bucket name
-     * @param key    The object key
-     * @throws IOException If the deletion fails
-     */
+
     public void deleteFromStagingBucket(String bucket, String key) throws IOException {
         try {
             DeleteObjectRequest deleteObjectRequest = DeleteObjectRequest.builder()

--- a/processing-service/src/main/java/com/process/util/S3UrlUtil.java
+++ b/processing-service/src/main/java/com/process/util/S3UrlUtil.java
@@ -1,0 +1,28 @@
+package com.process.util;
+
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest;
+
+import java.time.Duration;
+
+public class S3UrlUtil {
+    public static String generatePresignedUrl(String region, String bucket, String key) {
+        S3Presigner presigner = S3Presigner.builder()
+                .region(Region.of(region))
+                .build();
+
+        GetObjectRequest getObjectRequest = GetObjectRequest.builder()
+                .bucket(bucket)
+                .key(key)
+                .build();
+
+        GetObjectPresignRequest presignRequest = GetObjectPresignRequest.builder()
+                .signatureDuration(Duration.ofDays(7))  // Valid for 7 days
+                .getObjectRequest(getObjectRequest)
+                .build();
+
+        return presigner.presignGetObject(presignRequest).url().toString();
+    }
+}

--- a/template.yaml
+++ b/template.yaml
@@ -341,6 +341,37 @@ Resources:
         deadLetterTargetArn: !GetAtt DeadLetterQueue.Arn
         maxReceiveCount: 5
 
+  DLQRedriveRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+            Action: sts:AssumeRole
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+      Policies:
+        - PolicyName: SQSRedrivePolicy
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - sqs:ReceiveMessage
+                  - sqs:DeleteMessage
+                  - sqs:GetQueueAttributes
+                Resource: !GetAtt DeadLetterQueue.Arn
+              - Effect: Allow
+                Action:
+                  - sqs:SendMessage
+                  - sqs:GetQueueUrl
+                Resource: !GetAtt RetryQueue.Arn
+
+
+
   DeadLetterQueue:
     Type: AWS::SQS::Queue
     Properties:
@@ -530,6 +561,53 @@ Resources:
           Properties:
             Queue: !GetAtt RetryQueue.Arn
             BatchSize: 10
+
+
+  # Lambda Function for DLQ Redrive
+  DLQRedriveFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      FunctionName: !Sub "${Environment}-dlq-redrive-function"
+      CodeUri: processing-service
+      Handler: com.process.handler.DLQRedriveHandler::handleRequest
+      Description: Moves messages from DLQ back to main retry queue with delay
+      Runtime: java21
+      MemorySize: 512
+      Timeout: 300
+      Environment:
+        Variables:
+          DLQ_URL: !Ref DeadLetterQueue
+          RETRY_QUEUE_URL: !Ref RetryQueue
+          MAX_MESSAGES_TO_REDRIVE: 100
+          JAVA_TOOL_OPTIONS: -XX:+TieredCompilation -XX:TieredStopAtLevel=1
+      Role: !GetAtt DLQRedriveRole.Arn
+      Events:
+        ScheduledEvent:
+          Type: Schedule
+          Properties:
+            Schedule: rate(1 hour)
+            Enabled: true
+            Description: "Schedule for DLQ redrive processing"
+
+  DLQMessagesAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub "${AWS::StackName}-dlq-messages-alarm"
+      AlarmDescription: "Alarm when messages accumulate in the Dead Letter Queue"
+      Namespace: AWS/SQS
+      MetricName: ApproximateNumberOfMessagesVisible
+      Dimensions:
+        - Name: QueueName
+          Value: !GetAtt DeadLetterQueue.QueueName
+      Statistic: Sum
+      Period: 300
+      EvaluationPeriods: 1
+      Threshold: 1
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      AlarmActions:
+        - !Ref HealthAlertTopic
+      OKActions:
+        - !Ref HealthAlertTopic
 
   # ===== Lambda Functions: Image Sharing =====
   GetActiveImagesFunction:


### PR DESCRIPTION
This PR introduces a scheduled AWS Lambda function that moves messages from the Dead Letter Queue (DLQ) back to the main retry queue with a configured delay. This helps in reprocessing failed image processing requests in a controlled manner.

Changes Implemented
DLQRedriveHandler Lambda Function:

Reads messages from the DLQ.

Forwards them to the retry queue with a 5-minute delay (DELAY_SECONDS = 300).

Deletes successfully forwarded messages from the DLQ.

Includes batch processing with limits to control throughput (MAX_MESSAGES_PER_BATCH, MAX_MESSAGES_TO_REDRIVE).

S3UrlUtil Utility Class:

Added utility to generate 7-day pre-signed S3 URLs. (Reusable for downstream image fetching or logging/debugging.)

IAM Role (DLQRedriveRole):

Grants necessary permissions for receiving, sending, and deleting messages from SQS.

CloudFormation Resources:

Added DLQRedriveFunction Lambda resource with scheduled event trigger (rate(1 hour)).

Added DLQMessagesAlarm to alert when messages are piling up in the DLQ.