### PR TITLE
Feat/recycle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,8 @@ yarn-error.log*
 .env.development.local
 .env.test.local
 .env.production.local
+.aws-sam
+samconfig.toml
 
 # Test files
 test-event.json

--- a/recycle-service/src/main/java/com/factories/AwsFactory.java
+++ b/recycle-service/src/main/java/com/factories/AwsFactory.java
@@ -9,14 +9,14 @@ public class AwsFactory {
     public static S3Client s3Client(){
         return  S3Client.builder()
                 .credentialsProvider(DefaultCredentialsProvider.create())
-                .region(Region.EU_CENTRAL_1)
+                .region(Region.US_EAST_1)
                 .build();
 
     }
     public static DynamoDbClient dynamoDbClient() {
         return DynamoDbClient.builder()
                 .credentialsProvider(DefaultCredentialsProvider.create())
-                .region(Region.EU_CENTRAL_1)
+                .region(Region.US_EAST_1)
                 .build();
     }
 

--- a/recycle-service/src/main/java/com/handlers/DeleteImageHandler.java
+++ b/recycle-service/src/main/java/com/handlers/DeleteImageHandler.java
@@ -79,6 +79,4 @@ public class DeleteImageHandler implements RequestHandler<APIGatewayProxyRequest
             return ResponseUtils.errorResponse(500, "Internal server error");
         }
     }
-
-
 }

--- a/recycle-service/src/test/java/com/factories/AwsFactoryTest.java
+++ b/recycle-service/src/test/java/com/factories/AwsFactoryTest.java
@@ -1,7 +1,10 @@
 package com.factories;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
 import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
@@ -9,56 +12,69 @@ import software.amazon.awssdk.services.dynamodb.DynamoDbClientBuilder;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.S3ClientBuilder;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 class AwsFactoryTest {
 
+    @Mock
+    private S3ClientBuilder mockS3Builder;
+
+    @Mock
+    private S3Client mockS3Client;
+
+    @Mock
+    private DynamoDbClientBuilder mockDynamoBuilder;
+
+    @Mock
+    private DynamoDbClient mockDynamoClient;
+
+    @BeforeEach
+    void setup() {
+        mockS3Builder = mock(S3ClientBuilder.class);
+        mockS3Client = mock(S3Client.class);
+
+        mockDynamoBuilder = mock(DynamoDbClientBuilder.class);
+        mockDynamoClient = mock(DynamoDbClient.class);
+    }
 
     @Test
     void testS3Client_NotNull_AndConfiguredCorrectly() {
-        S3ClientBuilder mockBuilder = mock(S3ClientBuilder.class);
-        S3Client mockClient = mock(S3Client.class);
+        try (MockedStatic<S3Client> staticS3 = Mockito.mockStatic(S3Client.class)) {
+            staticS3.when(S3Client::builder).thenReturn(mockS3Builder);
 
-        try (MockedStatic<S3Client> mockedStatic = mockStatic(S3Client.class)) {
-            mockedStatic.when(S3Client::builder).thenReturn(mockBuilder);
-
-            when(mockBuilder.credentialsProvider(any(DefaultCredentialsProvider.class))).thenReturn(mockBuilder);
-            when(mockBuilder.region(Region.US_EAST_1)).thenReturn(mockBuilder);
-            when(mockBuilder.build()).thenReturn(mockClient);
+            when(mockS3Builder.credentialsProvider(any(DefaultCredentialsProvider.class))).thenReturn(mockS3Builder);
+            when(mockS3Builder.region(Region.US_EAST_1)).thenReturn(mockS3Builder);
+            when(mockS3Builder.build()).thenReturn(mockS3Client);
 
             S3Client result = AwsFactory.s3Client();
 
             assertNotNull(result);
-            assertEquals(mockClient, result);
+            assertEquals(mockS3Client, result);
 
-            verify(mockBuilder).credentialsProvider(any(DefaultCredentialsProvider.class));
-            verify(mockBuilder).region(Region.US_EAST_1);
-            verify(mockBuilder).build();
+            verify(mockS3Builder).credentialsProvider(any(DefaultCredentialsProvider.class));
+            verify(mockS3Builder).region(Region.US_EAST_1);
+            verify(mockS3Builder).build();
         }
     }
 
     @Test
     void testDynamoDbClient_NotNull_AndConfiguredCorrectly() {
-        DynamoDbClientBuilder mockBuilder = mock(DynamoDbClientBuilder.class);
-        DynamoDbClient mockClient = mock(DynamoDbClient.class);
+        try (MockedStatic<DynamoDbClient> staticDynamo = Mockito.mockStatic(DynamoDbClient.class)) {
+            staticDynamo.when(DynamoDbClient::builder).thenReturn(mockDynamoBuilder);
 
-        try (MockedStatic<DynamoDbClient> mockedStatic = mockStatic(DynamoDbClient.class)) {
-            mockedStatic.when(DynamoDbClient::builder).thenReturn(mockBuilder);
-
-            when(mockBuilder.credentialsProvider(any(DefaultCredentialsProvider.class))).thenReturn(mockBuilder);
-            when(mockBuilder.region(Region.US_EAST_1)).thenReturn(mockBuilder);
-            when(mockBuilder.build()).thenReturn(mockClient);
+            when(mockDynamoBuilder.credentialsProvider(any(DefaultCredentialsProvider.class))).thenReturn(mockDynamoBuilder);
+            when(mockDynamoBuilder.region(Region.US_EAST_1)).thenReturn(mockDynamoBuilder);
+            when(mockDynamoBuilder.build()).thenReturn(mockDynamoClient);
 
             DynamoDbClient result = AwsFactory.dynamoDbClient();
 
             assertNotNull(result);
-            assertEquals(mockClient, result);
+            assertEquals(mockDynamoClient, result);
 
-            verify(mockBuilder).credentialsProvider(any(DefaultCredentialsProvider.class));
-            verify(mockBuilder).region(Region.US_EAST_1);
-            verify(mockBuilder).build();
+            verify(mockDynamoBuilder).credentialsProvider(any(DefaultCredentialsProvider.class));
+            verify(mockDynamoBuilder).region(Region.US_EAST_1);
+            verify(mockDynamoBuilder).build();
         }
     }
 }

--- a/recycle-service/src/test/java/com/factories/AwsFactoryTest.java
+++ b/recycle-service/src/test/java/com/factories/AwsFactoryTest.java
@@ -1,0 +1,64 @@
+package com.factories;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClientBuilder;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.S3ClientBuilder;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.*;
+
+class AwsFactoryTest {
+
+
+    @Test
+    void testS3Client_NotNull_AndConfiguredCorrectly() {
+        S3ClientBuilder mockBuilder = mock(S3ClientBuilder.class);
+        S3Client mockClient = mock(S3Client.class);
+
+        try (MockedStatic<S3Client> mockedStatic = mockStatic(S3Client.class)) {
+            mockedStatic.when(S3Client::builder).thenReturn(mockBuilder);
+
+            when(mockBuilder.credentialsProvider(any(DefaultCredentialsProvider.class))).thenReturn(mockBuilder);
+            when(mockBuilder.region(Region.US_EAST_1)).thenReturn(mockBuilder);
+            when(mockBuilder.build()).thenReturn(mockClient);
+
+            S3Client result = AwsFactory.s3Client();
+
+            assertNotNull(result);
+            assertEquals(mockClient, result);
+
+            verify(mockBuilder).credentialsProvider(any(DefaultCredentialsProvider.class));
+            verify(mockBuilder).region(Region.US_EAST_1);
+            verify(mockBuilder).build();
+        }
+    }
+
+    @Test
+    void testDynamoDbClient_NotNull_AndConfiguredCorrectly() {
+        DynamoDbClientBuilder mockBuilder = mock(DynamoDbClientBuilder.class);
+        DynamoDbClient mockClient = mock(DynamoDbClient.class);
+
+        try (MockedStatic<DynamoDbClient> mockedStatic = mockStatic(DynamoDbClient.class)) {
+            mockedStatic.when(DynamoDbClient::builder).thenReturn(mockBuilder);
+
+            when(mockBuilder.credentialsProvider(any(DefaultCredentialsProvider.class))).thenReturn(mockBuilder);
+            when(mockBuilder.region(Region.US_EAST_1)).thenReturn(mockBuilder);
+            when(mockBuilder.build()).thenReturn(mockClient);
+
+            DynamoDbClient result = AwsFactory.dynamoDbClient();
+
+            assertNotNull(result);
+            assertEquals(mockClient, result);
+
+            verify(mockBuilder).credentialsProvider(any(DefaultCredentialsProvider.class));
+            verify(mockBuilder).region(Region.US_EAST_1);
+            verify(mockBuilder).build();
+        }
+    }
+}

--- a/samconfig.toml
+++ b/samconfig.toml
@@ -14,12 +14,13 @@ lint = true
 
 [default.deploy.parameters]
 capabilities = "CAPABILITY_IAM"
-confirm_changeset = false
+confirm_changeset = true
 resolve_s3 = true
-s3_prefix = "photo-processing-blog"
+s3_prefix = "photo-share-image-app"
 region = "us-east-1"
-parameter_overrides = "Environment=\"prod\" ImageTableName=\"photo\" RetryQueueName=\"image-retry-queue\" EmailDomain=\"mscv2group2.link\" AdminEmail=\"vidaserwaa26@gmail.com\" HealthCheckPath=\"/health\" HealthCheckInterval=\"30\" HealthCheckFailureThreshold=\"3\" ErrorThreshold=\"5\" EvaluationPeriod=\"5\" DomainName=\"photo.mscv2group2.link\" HostedZoneId=\"Z07888711CCI43RK69LKQ\""
+parameter_overrides = "Environment=\"dev\" ImageTableName=\"imageTable\" RetryQueueName=\"image-retry-queue\" EmailDomain=\"mscv2group2.link\" AdminEmail=\"vidaserwaa26@gmail.com\" HealthCheckPath=\"/health\" HealthCheckInterval=\"30\" HealthCheckFailureThreshold=\"3\" ErrorThreshold=\"5\" EvaluationPeriod=\"5\" DomainName=\"photo.mscv2group2.link\" HostedZoneId=\"Z07888711CCI43RK69LKQ\" DestinationRegion=\"us-west-2\" ReplicaRegions=\"us-west-2, eu-west-1\""
 image_repositories = []
+stack_name = "photo-share-image-app"
 
 [default.sync.parameters]
 watch = true

--- a/template.yaml
+++ b/template.yaml
@@ -154,24 +154,24 @@ Resources:
                 uri: !Sub "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${UploadImageFunction.Arn}/invocations"
                 httpMethod: POST
                 type: aws_proxy
-          # /images/{photoId}/delete:
-          #   post:
-          #     x-amazon-apigateway-integration:
-          #       uri: !Sub "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${DeleteImageFunction.Arn}/invocations"
-          #       httpMethod: POST
-          #       type: aws_proxy
-          # /images/{photoId}/restore:
-          #   post:
-          #     x-amazon-apigateway-integration:
-          #       uri: !Sub "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${RecoverImageFunction.Arn}/invocations"
-          #       httpMethod: POST
-          #       type: aws_proxy
-          # /images/{photoId}/permanent-delete:
-          #   delete:
-          #     x-amazon-apigateway-integration:
-          #       uri: !Sub "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${PermanentlyDeleteImageFunction.Arn}/invocations"
-          #       httpMethod: POST
-          #       type: aws_proxy
+          /images/{photoId}/delete:
+            post:
+              x-amazon-apigateway-integration:
+                uri: !Sub "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${DeleteImageFunction.Arn}/invocations"
+                httpMethod: POST
+                type: aws_proxy
+          /images/{photoId}/restore:
+            post:
+              x-amazon-apigateway-integration:
+                uri: !Sub "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${RecoverImageFunction.Arn}/invocations"
+                httpMethod: POST
+                type: aws_proxy
+          /images/{photoId}/permanent-delete:
+            delete:
+              x-amazon-apigateway-integration:
+                uri: !Sub "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${PermanentlyDeleteImageFunction.Arn}/invocations"
+                httpMethod: POST
+                type: aws_proxy
           /health:
             get:
               x-amazon-apigateway-integration:
@@ -276,6 +276,12 @@ Resources:
               Status: Disabled
             Filter:
               Prefix: ""  # Replicate all objects; modify if needed
+      LifecycleConfiguration:
+        Rules:
+          - Id: AutoDeleteAfter30Days
+            Prefix: recycle/
+            Status: Enabled
+            ExpirationInDays: 30
 
   DestinationBucket:
     Type: AWS::S3::Bucket
@@ -776,86 +782,87 @@ Resources:
         Environment: !Ref Environment
 
   # ===== Lambda Functions: Recycle Bin Feature =====
-  # DeleteImageFunction:
-  #   Type: AWS::Serverless::Function
-  #   Properties:
-  #     FunctionName: !Sub "image-delete-function-${Environment}"
-  #     CodeUri: recycle-service/
-  #     Handler: com.handlers.DeleteImageHandler::handleRequest
-  #     Description: Moves images to the recycle bin
-  #     Environment:
-  #       Variables:
-  #         PRIMARY_BUCKET: !Ref ProcessedBucket
-  #         IMAGE_TABLE: !Ref ImageTableName
-  #         RECYCLE_BUCKET: !Ref RecycleBinBucket
-  #         ENVIRONMENT: !Ref Environment
-  #     Policies:
-  #       - DynamoDBCrudPolicy:
-  #           TableName: !Ref PhotoTable
-  #       - S3CrudPolicy:
-  #           BucketName: !Ref ProcessedBucket
-  #       - S3CrudPolicy:
-  #           BucketName: !Ref RecycleBinBucket
-  #     Events:
-  #       ApiEvent:
-  #         Type: Api
-  #         Properties:
-  #           RestApiId: !Ref ApiGateway
-  #           Path: /images/{photoId}/delete
-  #           Method: post
+  DeleteImageFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      FunctionName: !Sub "image-delete-function-${Environment}"
+      CodeUri: recycle-service/
+      Handler: com.handlers.DeleteImageHandler::handleRequest
+      Description: Moves images to the recycle bin
+      Environment:
+        Variables:
+          PRIMARY_BUCKET: !Ref ProcessedBucket
+          IMAGE_TABLE: !Ref ImageTableName
+          RECYCLE_BUCKET: !Ref RecycleBinBucket
+          ENVIRONMENT: !Ref Environment
+      Policies:
+        - DynamoDBCrudPolicy:
+            TableName: !Ref PhotoTable
+        - S3CrudPolicy:
+            BucketName: !Ref ProcessedBucket
+        - S3CrudPolicy:
+            BucketName: !Ref RecycleBinBucket
+      Events:
+        ApiEvent:
+          Type: Api
+          Properties:
+            RestApiId: !Ref ApiGateway
+            Path: /images/{photoId}/delete
+            Method: post
 
-  # RecoverImageFunction:
-  #   Type: AWS::Serverless::Function
-  #   Properties:
-  #     FunctionName: !Sub "image-recover-function-${Environment}"
-  #     CodeUri: recycle-service/
-  #     Handler: com.handlers.RecoverImageHandler::handleRequest
-  #     Description: Restores images from the recycle bin
-  #     Environment:
-  #       Variables:
-  #         PRIMARY_BUCKET: !Ref ProcessedBucket
-  #         IMAGE_TABLE: !Ref ImageTableName
-  #         RECYCLE_BUCKET: !Ref RecycleBinBucket
-  #         ENVIRONMENT: !Ref Environment
-  #     Policies:
-  #       - DynamoDBCrudPolicy:
-  #           TableName: !Ref PhotoTable
-  #       - S3CrudPolicy:
-  #           BucketName: !Ref ProcessedBucket
-  #       - S3CrudPolicy:
-  #           BucketName: !Ref RecycleBinBucket
-  #     Events:
-  #       ApiEvent:
-  #         Type: Api
-  #         Properties:
-  #           RestApiId: !Ref ApiGateway
-  #           Path: /images/{photoId}/restore
-  #           Method: post
+  RecoverImageFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      FunctionName: !Sub "image-recover-function-${Environment}"
+      CodeUri: recycle-service/
+      Handler: com.handlers.RecoverImageHandler::handleRequest
+      Description: Restores images from the recycle bin
+      Environment:
+        Variables:
+          PRIMARY_BUCKET: !Ref ProcessedBucket
+          IMAGE_TABLE: !Ref ImageTableName
+          RECYCLE_BUCKET: !Ref RecycleBinBucket
+          ENVIRONMENT: !Ref Environment
+      Policies:
+        - DynamoDBCrudPolicy:
+            TableName: !Ref PhotoTable
+        - S3CrudPolicy:
+            BucketName: !Ref ProcessedBucket
+        - S3CrudPolicy:
+            BucketName: !Ref RecycleBinBucket
+      Events:
+        ApiEvent:
+          Type: Api
+          Properties:
+            RestApiId: !Ref ApiGateway
+            Path: /images/{photoId}/restore
+            Method: post
 
-  # PermanentlyDeleteImageFunction:
-  #   Type: AWS::Serverless::Function
-  #   Properties:
-  #     FunctionName: !Sub "image-permanent-delete-function-${Environment}"
-  #     CodeUri: recycle-service/
-  #     Handler: com.handlers.PermanentlyDeleteImageHandler::handleRequest
-  #     Description: Permanently deletes images from the recycle bin
-  #     Environment:
-  #       Variables:
-  #         IMAGE_TABLE: !Ref ImageTableName
-  #         RECYCLE_BUCKET: !Ref RecycleBinBucket
-  #         ENVIRONMENT: !Ref Environment
-  #     Policies:
-  #       - DynamoDBCrudPolicy:
-  #           TableName: !Ref PhotoTable
-  #       - S3CrudPolicy:
-  #           BucketName: !Ref RecycleBinBucket
-  #     Events:
-  #       ApiEvent:
-  #         Type: Api
-  #         Properties:
-  #           RestApiId: !Ref ApiGateway
-  #           Path: /images/{photoId}/permanent-delete
-  #           Method: delete
+  PermanentlyDeleteImageFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      FunctionName: !Sub "image-permanent-delete-function-${Environment}"
+      CodeUri: recycle-service/
+      Handler: com.handlers.PermanentlyDeleteImageHandler::handleRequest
+      Description: Permanently deletes images from the recycle bin
+      Environment:
+        Variables:
+          IMAGE_TABLE: !Ref ImageTableName
+          RECYCLE_BUCKET: !Ref RecycleBinBucket
+          ENVIRONMENT: !Ref Environment
+          PRIMARY_BUCKET: !Ref ProcessedBucket
+      Policies:
+        - DynamoDBCrudPolicy:
+            TableName: !Ref PhotoTable
+        - S3CrudPolicy:
+            BucketName: !Ref RecycleBinBucket
+      Events:
+        ApiEvent:
+          Type: Api
+          Properties:
+            RestApiId: !Ref ApiGateway
+            Path: /images/{photoId}/permanent-delete
+            Method: delete
 
   # ===== Lambda Functions: Authentication =====
   PostConfirmationLambda:
@@ -1031,7 +1038,7 @@ Resources:
                 - s3:GetBucketVersioning
                 - s3:GetBucketTagging
                 - s3:ListBucket
-              Resource: 
+              Resource:
                 - !Sub "arn:aws:s3:::${ProcessedBucket}"
                 - !Sub "arn:aws:s3:::${ProcessedBucket}/*"
             - Effect: Allow


### PR DESCRIPTION
test: add unit tests for AwsFactory methods using @BeforeEach setup

- Mocked S3Client and DynamoDbClient builders
- Verified configuration steps (region, credentialsProvider, build)
- Ensured returned clients are not null
- Used MockedStatic to isolate static method calls
