### PR TITLE
Fix/Cognito backup region and IAM permissions

### DIFF
--- a/cognito-service/src/main/java/com/amalitechphotoappcognitoauth/handlers/BackupHandler.java
+++ b/cognito-service/src/main/java/com/amalitechphotoappcognitoauth/handlers/BackupHandler.java
@@ -26,17 +26,20 @@ public class BackupHandler implements RequestHandler<ScheduledEvent, String> {
     private final Gson gson;
 
     public BackupHandler() {
-        // Initialize AWS clients
-        this.cognitoClient = CognitoIdentityProviderClient.builder()
-                .region(Region.EU_CENTRAL_1)
-                .build();
-        this.dynamoDbClient = DynamoDbClient.builder()
-                .region(Region.EU_CENTRAL_1)
-                .build();
-
         // Get environment variables
         this.userPoolId = System.getenv("USER_POOL_ID");
         this.backupTable = System.getenv("BACKUP_TABLE");
+        
+        // Get region from environment or use the same region as the Lambda function
+        String region = System.getenv("AWS_REGION") != null ? System.getenv("AWS_REGION") : "us-east-1";
+        
+        // Initialize AWS clients with the correct region
+        this.cognitoClient = CognitoIdentityProviderClient.builder()
+                .region(Region.of(region))
+                .build();
+        this.dynamoDbClient = DynamoDbClient.builder()
+                .region(Region.of(region))
+                .build();
 
         // Initialize Gson with custom type adapter for Instant
         this.gson = new GsonBuilder()

--- a/template.yaml
+++ b/template.yaml
@@ -428,21 +428,15 @@ Resources:
             Statement:
               - Effect: Allow
                 Action:
-                  - cognito-idp:ListUsers
                   - cognito-idp:DescribeUserPool
-                Resource: !Sub "arn:aws:cognito-idp:${AWS::Region}:${AWS::AccountId}:userpool/${CognitoUserPool}"
+                  - cognito-idp:ListUsers
+                  - cognito-idp:ListUsersInGroup
+                  - cognito-idp:ListGroups
+                Resource: !Sub "arn:aws:cognito-idp:*:${AWS::AccountId}:userpool/*"
               - Effect: Allow
                 Action:
                   - dynamodb:PutItem
-                  - dynamodb:GetItem
-                  - dynamodb:Query
-                  - dynamodb:Scan
-                  - dynamodb:BatchWriteItem
-                  - dynamodb:DeleteItem
-                  - dynamodb:UpdateItem
-                Resource:
-                  - !GetAtt BackupTable.Arn
-                  - !Sub "${BackupTable.Arn}/index/*"
+                Resource: !GetAtt BackupTable.Arn
 
   CognitoBackupFunction:
     Type: AWS::Serverless::Function


### PR DESCRIPTION

- Added default region fallback to us-east-1 when AWS_REGION is not available
- Updated IAM role with required permissions for Cognito operations
- Fixed region handling to ensure consistent access to AWS resources